### PR TITLE
Fix a jRuby issue with refinements

### DIFF
--- a/lib/aldagai/colors.rb
+++ b/lib/aldagai/colors.rb
@@ -4,31 +4,27 @@ module Aldagai
     refine String do
 
       def red
-        colorize(31)
+        "\e[31m#{self}\e[0m"
       end
 
       def green
-        colorize(32)
+        "\e[32m#{self}\e[0m"
       end
 
       def yellow
-        colorize(33)
+        "\e[33m#{self}\e[0m"
       end
 
       def blue
-        colorize(34)
+        "\e[34m#{self}\e[0m"
       end
 
       def pink
-        colorize(35)
+        "\e[35m#{self}\e[0m"
       end
 
       def light_blue
-        colorize(36)
-      end
-
-      def colorize(color_code)
-        "\e[#{color_code}m#{self}\e[0m"
+        "\e[36m#{self}\e[0m"
       end
 
     end

--- a/lib/aldagai/version.rb
+++ b/lib/aldagai/version.rb
@@ -1,3 +1,3 @@
 module Aldagai
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
Refinments where not able to call functions defined within the
refinment, instead of calling the function just rewrote the body.