### PR TITLE
Add command to set new variables in a temporal execution

### DIFF
--- a/lib/aldagai/cli.rb
+++ b/lib/aldagai/cli.rb
@@ -61,5 +61,11 @@ module Aldagai
       @manager.set
     end
 
+    desc 'set_temp', 'Sets variables in temporal execution ENV'
+    def set_temp
+      @manager = Aldagai::NormalVariableManager.new
+
+      @manager.set_temp
+    end
   end
 end

--- a/lib/aldagai/variable_managers/base.rb
+++ b/lib/aldagai/variable_managers/base.rb
@@ -95,18 +95,23 @@ module Aldagai
       if lines.empty?
         log_no_variables_promoted(ENV['ALDAGAI_PIPELINE_ENV'])
       else
-        variables = {}
-
-        lines.each do |line|
-          name, value = line.split('=')
-          value = value_presence(value)
-
-          log_variable_was_added_or_removed(name, value)
-
-          variables.merge!({name => value})
-        end
+        variables = get_variables_from_lines(lines)
 
         heroku.config_var.update(ENV['ALDAGAI_APP_NAME'], variables)
+      end
+    end
+
+    def set_temp
+      lines  = lines_for_environment(ENV['ALDAGAI_PIPELINE_ENV'])
+
+      if lines.empty?
+        log_no_variables_promoted(ENV['ALDAGAI_PIPELINE_ENV'])
+      else
+        variables = get_variables_from_lines(lines)
+
+        variables.each do |(key, value)|
+          ENV[key] = value
+        end
       end
     end
 
@@ -114,6 +119,21 @@ module Aldagai
 
     def environments
       DEFAULT_ENVIRONMENTS
+    end
+
+    def get_variables_from_lines(lines)
+      variables = {}
+
+      lines.each do |line|
+        name, value = line.split('=')
+        value = value_presence(value)
+
+        log_variable_was_added_or_removed(name, value)
+
+        variables.merge!({name => value})
+      end
+
+      variables
     end
 
     def rewrite_file_with_lines(environment, lines, &block)

--- a/lib/aldagai/version.rb
+++ b/lib/aldagai/version.rb
@@ -1,3 +1,3 @@
 module Aldagai
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
This command will set new variables on the process ENV. This could be
useful for heroku builds, in which you need the new variable in it,
 because the variable will be set on Heroku after it finishes.